### PR TITLE
Add rule for static methods requiring @override

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ To use eslint-plugin-override, add it to your ESLint configuration file (.eslint
     "override"
   ],
   "rules": {
-    "override/rule-name": "error"
+    "override/require-override": "error",
+    "override/require-static-override": "error",
   }
 }
 ```

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,6 @@
 module.exports = {
     rules: {
-        'require-override': require('./rules/require-override')
+        'require-override': require('./rules/require-override'),
+        'require-static-override': require('./rules/require-static-override')
     }
 };

--- a/lib/rules/require-static-override.js
+++ b/lib/rules/require-static-override.js
@@ -2,9 +2,10 @@ const { ESLintUtils } = require('@typescript-eslint/utils');
 const ts = require('typescript');
 
 // Function to get methods from the base class that are marked with @override
-function getOverrideMethods(symbol, ts) {
-    return symbol.members ? Array.from(symbol.members.values()).filter(member => {
-        return member.valueDeclaration && ts.isMethodDeclaration(member.valueDeclaration);
+function getStaticOverrideMethods(symbol, ts) {
+    return symbol.exports ? Array.from(symbol.exports.values()).filter(member => {
+        return member.valueDeclaration && ts.isMethodDeclaration(member.valueDeclaration) &&
+            member.valueDeclaration.modifiers && member.valueDeclaration.modifiers.some(mod => mod.kind === ts.SyntaxKind.StaticKeyword);
     }).filter(method => {
         const comments = ts.getLeadingCommentRanges(method.valueDeclaration.getFullText(), 0);
         if (!comments) return false;
@@ -35,7 +36,7 @@ function createFix(fixer, derivedMethods, overrideMethod, node) {
 }
 
 // Function to check if methods in the derived class are overridden
-function checkOverrideMethods(context, node, overrideMethods, derivedMethods) {
+function checkStaticOverrideMethods(context, node, overrideMethods, derivedMethods) {
     overrideMethods.forEach(overrideMethod => {
         const methodName = overrideMethod.getName();
         const isOverridden = derivedMethods.some(derivedMethod => derivedMethod.key.name === methodName);
@@ -70,22 +71,22 @@ function handleClass(context, node, ESLintUtils, ts) {
         return;
     }
 
-    const overrideMethods = getOverrideMethods(symbol, ts);
-    const derivedMethods = node.body.body.filter(method => method.type === 'MethodDefinition');
+    const staticOverrideMethods = getStaticOverrideMethods(symbol, ts);
+    const derivedStaticMethods = node.body.body.filter(method => method.type === 'MethodDefinition' && method.static);
 
-    checkOverrideMethods(context, node, overrideMethods, derivedMethods);
+    checkStaticOverrideMethods(context, node, staticOverrideMethods, derivedStaticMethods);
 }
 
 module.exports = {
     meta: {
         type: 'problem',
         docs: {
-            description: 'Ensure methods marked with @override are actually overridden in the derived class',
+            description: 'Ensure static methods marked with @override are actually overridden in the derived class',
             category: 'Best Practices',
             recommended: false
         },
         messages: {
-            noOverride: 'Method "{{ methodName }}" is marked with @override but is not overridden in the derived class.'
+            noOverride: 'Static method "{{ methodName }}" is marked with @override but is not overridden in the derived class.'
         },
         fixable: 'code', // This rule is fixable
         schema: [] // no options

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-override",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "A custom ESLint plugin to ensure methods marked with @override are actually overridden in the derived class",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
Expanded the ESLint plugin to include a new rule ensuring that static methods marked with @override in a base class are actually overridden in a derived class. Refactored existing logic for checking method overrides into reusable functions and integrated those into a new `require-static-override` rule. Updated README and incremented version to 0.3.0.